### PR TITLE
移除 Tencent 不再维护的 virtualbox 镜像

### DIFF
--- a/README.md
+++ b/README.md
@@ -1443,8 +1443,6 @@ git-fetch-with-cli = true
 
 #### Mirrors
 
-- Tencent
-  - [https://mirrors.cloud.tencent.com/virtualbox/](https://mirrors.cloud.tencent.com/virtualbox/)
 - 清华
   - [https://mirrors.tuna.tsinghua.edu.cn/virtualbox/](https://mirrors.tuna.tsinghua.edu.cn/virtualbox/)
 - 北京外国语大学


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 从 VirtualBox 虚拟机镜像列表中移除了腾讯镜像下载链接

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/opsre/Thanks-Mirror/pull/1100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->